### PR TITLE
Proofread Description of wallarm_acl_block_page

### DIFF
--- a/docs/2.14/admin-en/configure-parameters-en.md
+++ b/docs/2.14/admin-en/configure-parameters-en.md
@@ -1,4 +1,4 @@
-[doc-nginx-install]:    ../waf-installation/nginx/dynamic-module-from-distr.md
+a[doc-nginx-install]:    ../waf-installation/nginx/dynamic-module-from-distr.md
 [doc-eu-scanner-ip-addresses]: scanner-address-en.md
 [doc-us-scanner-ip-addresses]: scanner-address-us-en.md
 
@@ -141,7 +141,7 @@ By default, the response code 403 and default NGINX block page are returned to t
     This applies to both `wallarm_blocked.html` and to the custom block page.
 
 !!! info
-    This parameter can be set inside the http, server and location blocks.
+    This parameter can be set inside the http, server, and location blocks.
 
 ### wallarm_api_conf
 


### PR DESCRIPTION
Only read 1 section...

First read/ edited sentence: "Lets you set up the response code and the page returned..."

Last read/edited sentence: "This parameter can be set inside the http, server, and location blocks."