### PR TITLE
Proofread Compatibility of WAF with NGINX versions

### DIFF
--- a/faq/docs/waf-nginx-compatibility.md
+++ b/faq/docs/waf-nginx-compatibility.md
@@ -4,9 +4,9 @@
 
 No, Wallarm WAF is incompatible with NGINX `mainline`. You can install Wallarm WAF in the following ways:
 
-* connect to the official open source NGINX `stable` following the [instruction](../waf-installation/nginx/dynamic-module.md)
-* connect to NGINX installed from Debian/CentOS repositories following the [instruction](../waf-installation/nginx/dynamic-module-from-distr.md)
-* connect to the official commercial NGINX Plus following the [instruction](../waf-installation/nginx-plus.md)
+* connect to the official open source NGINX `stable` following these [instructions](../waf-installation/nginx/dynamic-module.md)
+* connect to NGINX installed from Debian/CentOS repositories following these [instructions](../waf-installation/nginx/dynamic-module-from-distr.md)
+* connect to the official commercial NGINX Plus following these [instructions](../waf-installation/nginx-plus.md)
 
 ## Is Wallarm WAF compatible with the custom build of NGINX?
 


### PR DESCRIPTION
Proofread of Compatibility of Wallarm WAF with NGINX versions located within the FAQ page